### PR TITLE
Make saved results visible on phones

### DIFF
--- a/app/components/calculator/index.tsx
+++ b/app/components/calculator/index.tsx
@@ -119,7 +119,7 @@ const Calculator = () => {
   return (
     <>
       <form
-        className="flex flex-col items-center justify-center flex-shrink-0 w-full max-w-md px-4 py-6 space-y-4 rounded-lg shadow-lg bg-card text-card-foreground"
+        className="flex flex-col items-center justify-center flex-shrink-0 w-full max-w-md mt-24 lg:mt-0 px-4 py-6 space-y-4 rounded-lg shadow-lg bg-card text-card-foreground"
         onSubmit={(e) => {
           e.preventDefault();
           saveResult();
@@ -159,7 +159,7 @@ const Calculator = () => {
           Save
         </Button>
       </form>
-      <div className="absolute invisible w-96 h-96 -bottom-24 lg:top-0 lg:right-0 lg:visible">
+      <div className="w-full max-w-md my-24 lg:w-96 lg:mt-0 lg:absolute lg:top-0 lg:right-0">
         <div className="bg-gray-100 rounded-md dark:bg-gray-700">
           <Results results={results} setResults={setResults} />
         </div>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -2,32 +2,42 @@ import Link from "next/link";
 
 const Footer = () => {
   return (
-    <div className="flex flex-col items-center justify-between w-full sm:flex-row">
-      <p >
-        Made by{" "}
+    <div className="flex flex-col lg:flex-row items-center justify-between w-full gap-4 lg:gap-0">
+      <div className="flex flex-col items-center lg:flex-row gap-4">
+        <p className="text-center lg:text-left">
+          Made by{" "}
+          <Link
+            role="link"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            href="https://twitter.com/max_leiter"
+            className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-600 hover:underline"
+          >
+            Max Leiter
+          </Link>
+          .
+        </p>
+        <p className="text-center lg:text-left">
+          {" "}
+          Source/sponsor on{" "}
+          <Link
+            role="link"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            href="https://github.com/MaxLeiter/easyarty"
+            className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-600 hover:underline"
+          >
+            GitHub
+          </Link>
+          .
+        </p>
+      </div>
+      <p className="text-center lg:text-left">
+        Recommended reading:{" "}
         <Link
-          role="link"
-          target="_blank"
-          rel="noopener noreferrer nofollow"
-          href="https://twitter.com/max_leiter"
+          href="/blog/artillery"
           className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-600 hover:underline"
         >
-          Max Leiter
-        </Link>
-        . Source/sponsor on{" "}
-        <Link
-          role="link"
-          target="_blank"
-          rel="noopener noreferrer nofollow"
-          href="https://github.com/MaxLeiter/easyarty"
-          className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-600 hover:underline"
-        >
-          GitHub
-        </Link>
-        .
-      </p>
-      <p className="hidden md:block">
-        Recommended reading:{" "}<Link href="/blog/artillery" className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-600 hover:underline">
           Efficiently using Artillery in Hell Let Loose
         </Link>
       </p>

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={clsx(
-          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -18,7 +18,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={clsx(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,12 +6,12 @@ import ThemeSwitch from "./components/theme-switcher";
 export default function Home() {
   return (
     <>
-      <div className="flex flex-col justify-between min-w-full min-h-screen">
+      <div className="flex flex-col justify-between min-w-full min-h-screen px-4 md:px-0">
         <section className="flex items-center justify-center w-full">
           <Header />
         </section>
         <main className="flex flex-col justify-center">
-          <section className="flex flex-col items-center justify-center flex-1 px-10 text-center">
+          <section className="flex flex-col items-center justify-center flex-1 text-center">
             <Calculator />
           </section>
         </main>


### PR DESCRIPTION
I use EasyArty on my phone almost every game, so first of all - thanks!

But I never knew what the "save" button did. That was until I opened EasyArty on my computer and saw that you could save distances. This pull request makes the saved results visible on phones as well.

Screenshots before:
<img height="300" alt="Skärmavbild 2024-07-22 kl  23 06 25" src="https://github.com/user-attachments/assets/6511a127-f1b1-4037-a1fb-256a32d3fbfa">
<img height="300" alt="Skärmavbild 2024-07-22 kl  23 06 45" src="https://github.com/user-attachments/assets/fe4217bc-47cb-489c-8e61-9bc0af700012">

Screenshots after:
<img height="300" alt="Skärmavbild 2024-07-22 kl  23 06 32" src="https://github.com/user-attachments/assets/1b0eb661-c8a1-4a3f-b230-1445cb02d0ac">
<img height="300" alt="Skärmavbild 2024-07-22 kl  23 06 56" src="https://github.com/user-attachments/assets/cb725d49-6398-47b9-be6c-3cfdeaa6dc4b">
<img height="300" alt="Skärmavbild 2024-07-22 kl  23 07 07" src="https://github.com/user-attachments/assets/7cb03d8a-5329-407d-a232-c97cc55ed1de">

